### PR TITLE
[FIX] muk_dms_export: refernce unavailable fields

### DIFF
--- a/muk_dms_export/views/dms_convert_view.xml
+++ b/muk_dms_export/views/dms_convert_view.xml
@@ -25,13 +25,10 @@
 	    <field name="mode">primary</field>
 	    <field name="inherit_id" ref="muk_converter.view_converter_convert_form"/>
 	    <field name="arch" type="xml">
-	    	<xpath expr="//field[@name='type']" position="attributes">
-	        	<attribute name="readonly">1</attribute>
-	        </xpath>
 	        <xpath expr="//field[@name='input_binary']" position="attributes">
 	        	<attribute name="invisible">1</attribute>
 	        </xpath>
-	        <xpath expr="//field[@name='type']" position="after">
+	        <xpath expr="//field[@name='input_binary']" position="after">
 	        	<field name="file" readonly="1" />
 	        </xpath>
 	        <xpath expr="//field[@name='format']" position="after">


### PR DESCRIPTION
Field type become unavailable in converter. So this commit changes code
to not use that field.