### PR TITLE
[11.0] Performance imporvement on muk_dms_attachment force storage

### DIFF
--- a/muk_dms_attachment/__manifest__.py
+++ b/muk_dms_attachment/__manifest__.py
@@ -1,5 +1,5 @@
 ###################################################################################
-# 
+#
 #    MuK Document Management System
 #
 #    Copyright (C) 2018 MuK IT GmbH
@@ -22,8 +22,8 @@
 {
     "name": "MuK Documents Attachment",
     "summary": """Documents as Attachment Storage""",
-    "version": '11.0.2.0.3',   
-    "category": 'Document Management',   
+    "version": '11.0.2.0.4',
+    "category": 'Document Management',
     "license": "AGPL-3",
     "website": "http://www.mukit.at",
     "live_test_url": "https://demo.mukit.at/web/login",


### PR DESCRIPTION
Same as [muk_base#19](https://github.com/muk-it/muk_base/pull/19) but related to `muk_dms_attachment`

--- 

This PR contains refactors `force_storage` method to be able to handle a lot of attachments.
May be this is not ideal solution, but it helped to migrate 8000+ attachments from lobject to filestore.

The reason for these modifications is that migration operation takes too long time for large databases.
Thus it is better to migrate attachments by small chunks and processing each chunks in separate transaction. Without this approach, when migration takes more than few minutes, there is possible transaction rollbacks or deadlocs due to parallel modifications, or in most frequent case timeouts. Especialy this may be important for odoo instances running on Odoo.SH or other hostings where there is no control on timeouts.

This PR do fillowing:
- cleanup `store_lobject` shen `location` is not `lobject`. this is required to  distinguish attachments that is not migrated yet. without this fix each time you press *Force Storage* button, odoo iterates over all attachments (including migrated attachments)
- Automatically detect attachments that have to be migrated. (To not migrate already migrated attachments)
- Migrate attachments by chunks of 100 elements. Each chunk processed in its own transaction. This allows to continue migration in case of transaction rollback or timeout errors.


Note, that this PR needs precise review and tests.