### PR TITLE
Update directory.py because of an error with subdirectories button

### DIFF
--- a/muk_dms/models/directory.py
+++ b/muk_dms/models/directory.py
@@ -241,7 +241,7 @@ class Directory(models.Model):
                 if operator == 'child_of':
                     directory_ids = self.search([('id', operator, directory_id)]).ids
                 directory_where_clause = 'WHERE r.did = ANY (VALUES {ids})'
-                where_clause = '' if not file_ids else directory_where_clause.format(
+                where_clause = '' if not files else directory_where_clause.format(
                     ids=', '.join(map(lambda id: '(%s)' % id, directory_ids))
                 )
             self.env.cr.execute(sql_query.format(directory_where_clause=where_clause), [])


### PR DESCRIPTION
File "/usr/local/lib/python3.5/dist-packages/odoo/addons/muk_dms/models/directory.py", line 244, in search_panel_select_multi_range
    where_clause = '' if not file_ids else directory_where_clause.format(
NameError: name 'file_ids' is not defined

There is an error line 244 : file_ids doesn’t exist.
 Is this field which was intended to be use ?
« files = fields.One2many(
        comodel_name='muk_dms.file', 
        inverse_name='directory',
        string="Files",
        auto_join=False,
        copy=False) »