### PR TITLE
[FIX] corrects function to set is_attachment automatically

### DIFF
--- a/muk_dms_attachment/models/file.py
+++ b/muk_dms_attachment/models/file.py
@@ -119,7 +119,7 @@ class File(models.Model):
             '&', ('is_store_document_link', '=', False),
             '|', ('res_field', '=', False), ('res_field', '!=', False)
         ])
-        data = {attach.store_document: attach for attach in attachments}
+        data = {attach.store_document.id: attach for attach in attachments}
         for record in self:
             if record.id in data:
                 record.update({


### PR DESCRIPTION
I have found an error after creating attachment of a document. The boolean field "is_attachment" will never be set.